### PR TITLE
Update XML sitemap entries

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,38 +2,44 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://postcode.blog/</loc>
-        <lastmod>2024-12-19</lastmod>
+        <lastmod>2024-06-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://postcode.blog/global.html</loc>
-        <lastmod>2024-12-19</lastmod>
+        <loc>https://postcode.blog/index.html</loc>
+        <lastmod>2024-06-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
     <url>
-        <loc>https://postcode.blog/statistics.html</loc>
-        <lastmod>2024-12-19</lastmod>
-        <changefreq>monthly</changefreq>
+        <loc>https://postcode.blog/global.html</loc>
+        <lastmod>2024-06-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://postcode.blog/post-office.html</loc>
+        <lastmod>2024-06-01</lastmod>
+        <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://postcode.blog/postal-code-guide.html</loc>
-        <lastmod>2024-12-19</lastmod>
+        <lastmod>2024-06-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.9</priority>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://postcode.blog/statistics.html</loc>
+        <lastmod>2024-06-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
     </url>
     <url>
         <loc>https://postcode.blog/sitemap.html</loc>
-        <lastmod>2024-12-19</lastmod>
+        <lastmod>2024-06-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
-    </url>
-    <url>
-        <loc>https://postcode.blog/post-office.html</loc>
-        <lastmod>2024-12-19</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
     </url>
 </urlset>


### PR DESCRIPTION
## Summary
- refresh the sitemap XML so each key page has an explicit `<url>` entry
- update last modified timestamps and priorities to better reflect current content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf92904ec8321886a963530cacab4