### PR TITLE
Add Chinese SIM card guides and navigation dropdown

### DIFF
--- a/china-mobile-sim.html
+++ b/china-mobile-sim.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>中国移动手机卡攻略｜全球通、5G智享、花卡权益与覆盖解析 - Postcode Blog</title>
+  <meta name="description" content="权威解析中国移动手机卡，涵盖全球通、5G智享、移动花卡、预付费旅游卡、家庭宽带融合、国际漫游及客服服务，为个人与企业提供精准选择建议。">
+  <link rel="canonical" href="https://postcode.blog/china-mobile-sim.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #0c8bff;
+      --primary-dark: #0564c3;
+      --bg: #f4fbff;
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --text: #0f172a;
+      --muted: #5b6c85;
+      --border: #d8e6f5;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: radial-gradient(circle at 15% 15%, #e6f5ff, #ffffff 55%);
+      color: var(--text);
+      line-height: 1.72;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    header {
+      background: rgba(255, 255, 255, 0.9);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .nav {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .logo {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--primary);
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      font-size: 0.95rem;
+      font-weight: 500;
+      align-items: center;
+    }
+
+    .nav-links > a {
+      color: var(--text);
+    }
+
+    .nav-item {
+      position: relative;
+    }
+
+    .nav-item > a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--text);
+    }
+
+    .nav-caret {
+      font-size: 0.7rem;
+      color: var(--muted);
+      transition: transform 0.2s ease;
+    }
+
+    .nav-item:hover .nav-caret,
+    .nav-item:focus-within .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .nav-item.active > a {
+      color: var(--primary);
+    }
+
+    .nav-item.active .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      left: 0;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 24px 50px -24px rgba(15, 23, 42, 0.45);
+      padding: 1rem;
+      min-width: 220px;
+      border: 1px solid var(--border);
+      z-index: 10;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .dropdown a {
+      color: var(--text);
+      font-weight: 500;
+      transition: color 0.2s ease, transform 0.2s ease;
+    }
+
+    .dropdown a:hover {
+      color: var(--primary);
+      transform: translateX(4px);
+    }
+
+    .nav-item:hover .dropdown,
+    .nav-item:focus-within .dropdown {
+      display: flex;
+    }
+
+    .nav-item.active .dropdown {
+      display: flex;
+    }
+
+    .dropdown a[aria-current="page"] {
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    main {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 3.5rem 1.5rem 5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 3rem;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, #0c8bff 0%, #7bc3ff 100%);
+      border-radius: 32px;
+      color: #fff;
+      padding: 3rem;
+      box-shadow: 0 32px 70px -34px rgba(12, 139, 255, 0.55);
+    }
+
+    .hero h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.3rem, 5vw, 3.2rem);
+      letter-spacing: -0.02em;
+    }
+
+    .hero p {
+      max-width: 660px;
+      margin: 0 0 1.8rem;
+      font-size: 1.05rem;
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .label-row {
+      display: flex;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+    }
+
+    .label {
+      background: rgba(255, 255, 255, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.42);
+      padding: 0.45rem 0.95rem;
+      border-radius: 999px;
+      font-weight: 500;
+      font-size: 0.85rem;
+    }
+
+    .section-title {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: 1.9rem;
+    }
+
+    .section-title p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 1.6rem;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 1.8rem;
+      border: 1px solid rgba(12, 139, 255, 0.16);
+      box-shadow: 0 20px 52px -32px rgba(12, 139, 255, 0.4);
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 1.22rem;
+    }
+
+    .card p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .card ul {
+      margin: 0;
+      padding-left: 1.2rem;
+      color: var(--muted);
+    }
+
+    .card ul li {
+      margin-bottom: 0.55rem;
+    }
+
+    .insight {
+      background: linear-gradient(135deg, rgba(12, 139, 255, 0.12), rgba(12, 139, 255, 0.05));
+      border-radius: 24px;
+      border: 1px solid rgba(12, 139, 255, 0.2);
+      padding: 2rem;
+      display: grid;
+      gap: 0.8rem;
+    }
+
+    .process {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .process-step {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(12, 139, 255, 0.14);
+      box-shadow: 0 18px 45px -30px rgba(15, 23, 42, 0.4);
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .process-step strong {
+      font-size: 1.05rem;
+    }
+
+    .faq {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .faq-item {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(12, 139, 255, 0.14);
+      box-shadow: 0 16px 42px -30px rgba(12, 139, 255, 0.35);
+    }
+
+    .faq-item h3 {
+      margin: 0 0 0.6rem;
+      font-size: 1.05rem;
+    }
+
+    footer {
+      padding: 3rem 1.5rem 4rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 720px) {
+      .hero {
+        padding: 2.4rem 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <a class="logo" href="/">Postcode Blog</a>
+      <div class="nav-links">
+        <a href="/finder/">Finder</a>
+        <a href="/lookup/">Lookup</a>
+        <a href="/search/">Search Directory</a>
+        <a href="/cities/">A–Z Cities</a>
+        <a href="/faq/">FAQ</a>
+        <div class="nav-item active">
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <div class="dropdown" role="menu">
+            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
+            <a href="/china-mobile-sim.html" role="menuitem" aria-current="page">中国移动手机卡</a>
+            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>中国移动手机卡与覆盖能力一站式指南</h1>
+      <p>中国移动拥有全球最大的移动用户规模与领先的 5G 基站数量，本篇聚焦其手机卡产品体系、网络优势与服务生态，助您高效完成套餐选择。</p>
+      <div class="label-row">
+        <span class="label">全球通尊享</span>
+        <span class="label">5G智享套餐</span>
+        <span class="label">移动花卡权益</span>
+        <span class="label">家庭宽带融合</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>产品体系速览</h2>
+      <p>结合中国移动官方资费手册与市场推广方案，从经典品牌到线上专属卡全面梳理。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>全球通</h3>
+        <p>主打高端商务，月租 129 元起，提供全球通贵宾客服、国内外漫游数据包与航空出行权益。</p>
+      </article>
+      <article class="card">
+        <h3>5G智享套餐</h3>
+        <p>覆盖 98 至 598 元档位，强调大流量、千兆宽带副卡共享，以及视频彩铃、云盘等权益。</p>
+      </article>
+      <article class="card">
+        <h3>移动花卡</h3>
+        <p>线上申请，月租 19-39 元，含定向流量与视频/音乐会员，适合学生与年轻群体。</p>
+      </article>
+      <article class="card">
+        <h3>预付费/旅游卡</h3>
+        <p>针对短期访客推出 7/15/30 日流量包，免押金，支持机场/口岸快速办理。</p>
+      </article>
+    </section>
+
+    <section class="section-title">
+      <h2>网络覆盖与技术优势</h2>
+      <p>基于中国移动公开运营数据分析其在城乡、沿海及高铁线路的 4G/5G 覆盖表现。</p>
+    </section>
+    <section class="insight">
+      <strong>重点数据</strong>
+      <ul>
+        <li>5G 基站超 150 万座，县城及重点乡镇实现连续覆盖。</li>
+        <li>VoLTE 语音覆盖率超过 99%，语音通话接通率居行业前列。</li>
+        <li>「移动云」「数智中台」赋能企业上云用数，为政企客户提供行业模组。</li>
+      </ul>
+    </section>
+
+    <section class="section-title">
+      <h2>办理与激活流程</h2>
+      <p>从线上下单到线下激活，确保符合实名制与账户安全要求。</p>
+    </section>
+    <section class="process">
+      <div class="process-step">
+        <strong>1. 线上选号</strong>
+        <span>通过「中国移动」APP、和包或官方商城选择号码，上传身份证信息并进行活体检测。</span>
+      </div>
+      <div class="process-step">
+        <strong>2. 快递核验/营业厅</strong>
+        <span>选择快递实名核身或至附近营业厅完成信息比对，部分城市支持智能终端自助办卡。</span>
+      </div>
+      <div class="process-step">
+        <strong>3. 套餐激活</strong>
+        <span>插卡后拨打 <strong>10086</strong> 或使用 APP 进行网络激活，检测 5G、VoLTE 及副卡功能。</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>家庭与企业融合方案</h2>
+      <p>围绕「移动云宽带」和「数智家庭」打造跨终端体验，为多终端用户提供一体化解决方案。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>移动智家</h3>
+        <ul>
+          <li>手机+宽带+高清电视一体化，最高支持千兆光纤与 Wi-Fi 6 路由。</li>
+          <li>和家亲 App 统一管理家庭成员流量、设备联网及智能家居。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>企业云卡</h3>
+        <ul>
+          <li>提供专属企业号段、账单合并、移动云安全防护。</li>
+          <li>可结合 5G 专网与边缘计算，为制造、物流场景提供低时延连接。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>权益补充</h3>
+        <ul>
+          <li>积分兑换航旅、娱乐及通信增值包，支持家庭共享。</li>
+          <li>与咪咕视频、和悦读等内容平台深度合作，提升会员价值。</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="faq">
+      <div class="faq-item">
+        <h3>外籍旅客如何快速办理？</h3>
+        <p>携护照与入境章至中国移动国际机场柜台或指定营业厅，选择短期旅游卡，现场完成信息录入与激活。</p>
+      </div>
+      <div class="faq-item">
+        <h3>如何暂停或保号？</h3>
+        <p>拨打 10086 或前往营业厅办理「停机保号」，最长期限 6 个月，期间保留号码及账户余额。</p>
+      </div>
+      <div class="faq-item">
+        <h3>宽带融合需要哪些条件？</h3>
+        <p>办理 129 元及以上 5G 套餐即可申请千兆宽带，需具备覆盖条件并签署家庭宽带服务协议。</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    © Postcode Blog — 中国移动手机卡信息参考中国移动官方公告、年度报告及工信部通信业统计数据。
+  </footer>
+</body>
+</html>

--- a/china-telecom-sim.html
+++ b/china-telecom-sim.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>中国电信手机卡深度解析｜天翼5G套餐、宽带融合、国际业务 - Postcode Blog</title>
+  <meta name="description" content="全面解析中国电信手机卡：涵盖天翼5G套餐、星卡、宽带融合方案、国际漫游与eSIM服务、营业厅办理流程及政企业务亮点。">
+  <link rel="canonical" href="https://postcode.blog/china-telecom-sim.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #0f3dff;
+      --primary-dark: #0a2aa6;
+      --bg: #f5f7ff;
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --text: #0f172a;
+      --muted: #64748b;
+      --border: #e2e8f0;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(145deg, #f0f4ff 0%, #ffffff 65%, #f5f7ff 100%);
+      color: var(--text);
+      line-height: 1.7;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    header {
+      background: rgba(255, 255, 255, 0.92);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .nav {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .logo {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--primary);
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      font-size: 0.95rem;
+      font-weight: 500;
+      align-items: center;
+    }
+
+    .nav-links > a {
+      color: var(--text);
+    }
+
+    .nav-item {
+      position: relative;
+    }
+
+    .nav-item > a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--text);
+    }
+
+    .nav-caret {
+      font-size: 0.7rem;
+      color: var(--muted);
+      transition: transform 0.2s ease;
+    }
+
+    .nav-item:hover .nav-caret,
+    .nav-item:focus-within .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .nav-item.active > a {
+      color: var(--primary);
+    }
+
+    .nav-item.active .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      left: 0;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 22px 48px -22px rgba(15, 23, 42, 0.45);
+      padding: 1rem;
+      min-width: 220px;
+      border: 1px solid var(--border);
+      z-index: 10;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .dropdown a {
+      color: var(--text);
+      font-weight: 500;
+      transition: color 0.2s ease, transform 0.2s ease;
+    }
+
+    .dropdown a:hover {
+      color: var(--primary);
+      transform: translateX(4px);
+    }
+
+    .nav-item:hover .dropdown,
+    .nav-item:focus-within .dropdown {
+      display: flex;
+    }
+
+    .nav-item.active .dropdown {
+      display: flex;
+    }
+
+    .dropdown a[aria-current="page"] {
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    main {
+      max-width: 1020px;
+      margin: 0 auto;
+      padding: 3.5rem 1.5rem 5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 3rem;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, #0f3dff 0%, #6a8bff 100%);
+      border-radius: 32px;
+      color: #fff;
+      padding: 3rem;
+      box-shadow: 0 32px 68px -32px rgba(15, 61, 255, 0.55);
+    }
+
+    .hero h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.2rem, 5vw, 3.1rem);
+      letter-spacing: -0.02em;
+    }
+
+    .hero p {
+      max-width: 640px;
+      color: rgba(255, 255, 255, 0.92);
+      margin: 0 0 1.8rem;
+      font-size: 1.05rem;
+    }
+
+    .hero .tag-row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .tag {
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.42);
+      font-weight: 500;
+      font-size: 0.85rem;
+    }
+
+    .section-title {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: 1.9rem;
+    }
+
+    .section-title p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 1.6rem;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 1.8rem;
+      border: 1px solid rgba(255, 255, 255, 0.42);
+      box-shadow: 0 18px 50px -30px rgba(15, 23, 42, 0.5);
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .card p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .card ul {
+      margin: 0;
+      padding-left: 1.2rem;
+      color: var(--muted);
+    }
+
+    .card ul li {
+      margin-bottom: 0.55rem;
+    }
+
+    .highlight-box {
+      background: linear-gradient(135deg, rgba(15, 61, 255, 0.1), rgba(15, 61, 255, 0.05));
+      border: 1px solid rgba(15, 61, 255, 0.15);
+      border-radius: 24px;
+      padding: 2rem;
+      display: grid;
+      gap: 0.8rem;
+    }
+
+    .process {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .process-step {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(255, 255, 255, 0.42);
+      box-shadow: 0 16px 40px -28px rgba(15, 23, 42, 0.45);
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .process-step strong {
+      font-size: 1.05rem;
+    }
+
+    .faq {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .faq-item {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      box-shadow: 0 14px 38px -28px rgba(15, 23, 42, 0.45);
+    }
+
+    .faq-item h3 {
+      margin: 0 0 0.6rem;
+      font-size: 1.05rem;
+    }
+
+    footer {
+      padding: 3rem 1.5rem 4rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 720px) {
+      .hero {
+        padding: 2.4rem 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <a class="logo" href="/">Postcode Blog</a>
+      <div class="nav-links">
+        <a href="/finder/">Finder</a>
+        <a href="/lookup/">Lookup</a>
+        <a href="/search/">Search Directory</a>
+        <a href="/cities/">A–Z Cities</a>
+        <a href="/faq/">FAQ</a>
+        <div class="nav-item active">
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <div class="dropdown" role="menu">
+            <a href="/china-telecom-sim.html" role="menuitem" aria-current="page">中国电信手机卡</a>
+            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
+            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>中国电信手机卡与天翼5G全景解析</h1>
+      <p>作为中国领先的综合智能信息服务提供商，中国电信依托天翼5G、千兆宽带与云服务形成「云网融合」优势。本指南聚焦手机卡产品线，帮助个人与企业用户精准匹配套餐。</p>
+      <div class="tag-row">
+        <span class="tag">天翼5G全家桶</span>
+        <span class="tag">星卡/畅享套餐</span>
+        <span class="tag">国际漫游与eSIM</span>
+        <span class="tag">云宽带融合</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>核心产品矩阵</h2>
+      <p>根据中国电信最新产品发布及官方资费手册，梳理面向不同人群的手机卡方案。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>天翼5G套餐</h3>
+        <p>中高端档位覆盖129元至699元，提供5G优享/尊享网络优先级、家庭共享副卡、天翼云盘等权益。</p>
+      </article>
+      <article class="card">
+        <h3>星卡系列</h3>
+        <p>面向年轻用户的线上专属卡，月租19-39元，含定向流量、短视频/音乐权益，可线上自助办理。</p>
+      </article>
+      <article class="card">
+        <h3>融合宽带套餐</h3>
+        <p>「全家福」「乐享家」组合提供手机+固网+IPTV一体化服务，支持千兆宽带与智能组网。</p>
+      </article>
+      <article class="card">
+        <h3>政企业务专属卡</h3>
+        <p>聚焦政务、能源、交通等行业，提供物联网卡、专线+5G专网及安全管理平台。</p>
+      </article>
+    </section>
+
+    <section class="section-title">
+      <h2>实名制办理与线上渠道</h2>
+      <p>在工信部实名制监管体系下，中国电信提供多渠道便捷办理方式，确保个人信息安全。</p>
+    </section>
+    <section class="process">
+      <div class="process-step">
+        <strong>1. 线上预约</strong>
+        <span>通过中国电信 APP、天翼生活小程序或官方商城下单选择号码，完成证件上传与人脸识别。</span>
+      </div>
+      <div class="process-step">
+        <strong>2. 线下核验</strong>
+        <span>快递实名核验或前往营业厅出示身份证件。部分城市支持上门核验服务。</span>
+      </div>
+      <div class="process-step">
+        <strong>3. 套餐激活</strong>
+        <span>插卡后拨打 <strong>10000</strong> 或使用「天翼高清」App完成激活测试，确认语音、数据及副卡共享功能。</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>国际漫游与eSIM</h2>
+      <p>针对跨境商务人士，中国电信推出全球卡及eSIM产品，覆盖全球主要经济体。</p>
+    </section>
+    <section class="highlight-box">
+      <strong>关键亮点</strong>
+      <ul>
+        <li>全球漫游覆盖超过 200 个国家和地区，可在 APP 自助购买境外流量包。</li>
+        <li>eSIM 支持部分旗舰机型，国内可实现主副号码切换，适合频繁出差人士。</li>
+        <li>提供「国际港澳一卡双号」方案，在大湾区商务场景下保持通讯连续性。</li>
+      </ul>
+    </section>
+
+    <section class="section-title">
+      <h2>客户服务与增值权益</h2>
+      <p>天翼客服体系覆盖 24/7 热线、智能客服与政企业务经理，为高价值客户提供定制支持。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>服务渠道</h3>
+        <ul>
+          <li>10000 热线 + 「天翼客服」APP 实时工单。</li>
+          <li>全国 50,000+ 营业厅、合作便利店提供现场服务。</li>
+          <li>企业客户经理提供现场勘测与专属顾问支持。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>数字权益</h3>
+        <ul>
+          <li>天翼云盘、天翼看家、天翼云会议等多端云服务。</li>
+          <li>「翼支付」金融服务支持话费立减、积分兑换。</li>
+          <li>智慧家庭设备（路由器、摄像头）优惠购置。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>典型场景推荐</h3>
+        <ul>
+          <li>远程办公：选择 199 元及以上融合套餐，获得公网专线与云存储。</li>
+          <li>家庭宽带升级：办理「全屋光宽带」配合千兆 Wi-Fi 6 终端。</li>
+          <li>企业移动办公：使用政企云卡，支持 MDM 管理与专线接入。</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="faq">
+      <div class="faq-item">
+        <h3>如何在境外提前办理中国电信手机卡？</h3>
+        <p>可登录中国电信国际业务官网或授权旅行社，预先提交证件资料，抵达后在机场柜台完成激活。部分地区支持邮寄 SIM 到国内地址，由亲友代收。</p>
+      </div>
+      <div class="faq-item">
+        <h3>遗失手机卡怎么办？</h3>
+        <p>第一时间拨打 10000 或在 APP 申请临时停机挂失。凭身份证件到营业厅补卡，原号码、套餐及余额保持不变。</p>
+      </div>
+      <div class="faq-item">
+        <h3>如何注销或过户？</h3>
+        <p>持证件到营业厅办理销户或过户手续，清缴欠费后运营商将在 5 日内完成系统释放，确保个人信息安全。</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    © Postcode Blog — 中国电信手机卡信息来源于中国电信官方公告、2023 年财报及工信部统计公报。
+  </footer>
+</body>
+</html>

--- a/china-unicom-sim.html
+++ b/china-unicom-sim.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>中国联通手机卡详解｜5G套餐、冰激凌、国际漫游与副卡共享 - Postcode Blog</title>
+  <meta name="description" content="系统介绍中国联通手机卡方案，涵盖5G套餐、冰激凌与大众卡产品、国际漫游、港澳台合作、物联网与副卡共享策略，并提供办理流程与常见问题解答。">
+  <link rel="canonical" href="https://postcode.blog/china-unicom-sim.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #ff4b7d;
+      --primary-dark: #c23059;
+      --bg: #fff5f8;
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --text: #141d2f;
+      --muted: #6b7280;
+      --border: #f5d5df;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: radial-gradient(circle at 85% 15%, #ffe3ed, #ffffff 55%);
+      color: var(--text);
+      line-height: 1.72;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    header {
+      background: rgba(255, 255, 255, 0.9);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .nav {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .logo {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--primary);
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      font-size: 0.95rem;
+      font-weight: 500;
+      align-items: center;
+    }
+
+    .nav-links > a {
+      color: var(--text);
+    }
+
+    .nav-item {
+      position: relative;
+    }
+
+    .nav-item > a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--text);
+    }
+
+    .nav-caret {
+      font-size: 0.7rem;
+      color: var(--muted);
+      transition: transform 0.2s ease;
+    }
+
+    .nav-item:hover .nav-caret,
+    .nav-item:focus-within .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .nav-item.active > a {
+      color: var(--primary);
+    }
+
+    .nav-item.active .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      left: 0;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 22px 46px -24px rgba(20, 29, 47, 0.4);
+      padding: 1rem;
+      min-width: 220px;
+      border: 1px solid var(--border);
+      z-index: 10;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .dropdown a {
+      color: var(--text);
+      font-weight: 500;
+      transition: color 0.2s ease, transform 0.2s ease;
+    }
+
+    .dropdown a:hover {
+      color: var(--primary);
+      transform: translateX(4px);
+    }
+
+    .nav-item:hover .dropdown,
+    .nav-item:focus-within .dropdown {
+      display: flex;
+    }
+
+    .nav-item.active .dropdown {
+      display: flex;
+    }
+
+    .dropdown a[aria-current="page"] {
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    main {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 3.5rem 1.5rem 5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 3rem;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, #ff4b7d 0%, #ff88a9 100%);
+      border-radius: 32px;
+      color: #fff;
+      padding: 3rem;
+      box-shadow: 0 32px 68px -32px rgba(255, 75, 125, 0.55);
+    }
+
+    .hero h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.3rem, 5vw, 3.1rem);
+      letter-spacing: -0.02em;
+    }
+
+    .hero p {
+      max-width: 660px;
+      margin: 0 0 1.8rem;
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 1.05rem;
+    }
+
+    .chip-row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      background: rgba(255, 255, 255, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      font-weight: 500;
+      font-size: 0.85rem;
+    }
+
+    .section-title {
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: 1.9rem;
+    }
+
+    .section-title p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 1.6rem;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 1.8rem;
+      border: 1px solid rgba(255, 75, 125, 0.18);
+      box-shadow: 0 20px 52px -30px rgba(255, 75, 125, 0.35);
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 1.22rem;
+    }
+
+    .card p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .card ul {
+      margin: 0;
+      padding-left: 1.2rem;
+      color: var(--muted);
+    }
+
+    .card ul li {
+      margin-bottom: 0.55rem;
+    }
+
+    .insight {
+      background: linear-gradient(135deg, rgba(255, 75, 125, 0.12), rgba(255, 75, 125, 0.05));
+      border-radius: 24px;
+      border: 1px solid rgba(255, 75, 125, 0.2);
+      padding: 2rem;
+      display: grid;
+      gap: 0.8rem;
+    }
+
+    .process {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .process-step {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(255, 75, 125, 0.18);
+      box-shadow: 0 18px 45px -30px rgba(20, 29, 47, 0.4);
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .process-step strong {
+      font-size: 1.05rem;
+    }
+
+    .faq {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .faq-item {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(255, 75, 125, 0.16);
+      box-shadow: 0 16px 42px -30px rgba(20, 29, 47, 0.35);
+    }
+
+    .faq-item h3 {
+      margin: 0 0 0.6rem;
+      font-size: 1.05rem;
+    }
+
+    footer {
+      padding: 3rem 1.5rem 4rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 720px) {
+      .hero {
+        padding: 2.4rem 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <a class="logo" href="/">Postcode Blog</a>
+      <div class="nav-links">
+        <a href="/finder/">Finder</a>
+        <a href="/lookup/">Lookup</a>
+        <a href="/search/">Search Directory</a>
+        <a href="/cities/">A–Z Cities</a>
+        <a href="/faq/">FAQ</a>
+        <div class="nav-item active">
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <div class="dropdown" role="menu">
+            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
+            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
+            <a href="/china-unicom-sim.html" role="menuitem" aria-current="page">中国联通手机卡</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>中国联通手机卡与副卡共享策略深度指南</h1>
+      <p>中国联通凭借 5G 共建共享、冰激凌套餐与副卡共享政策形成差异化竞争力。本指南系统解析产品组合、办理流程与国际合作亮点。</p>
+      <div class="chip-row">
+        <span class="chip">联通5G套餐</span>
+        <span class="chip">冰激凌与大众卡</span>
+        <span class="chip">港澳台数据合作</span>
+        <span class="chip">副卡与物联网</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>产品矩阵</h2>
+      <p>依据中国联通官方公告和线上商城信息，梳理面向不同用户群体的手机卡选择。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>联通5G套餐</h3>
+        <p>价格覆盖 99-699 元，提供 5G 极速通道、副卡共享及沃云盘等服务，强调家庭/企业融合。</p>
+      </article>
+      <article class="card">
+        <h3>冰激凌系列</h3>
+        <p>以大流量无限速为卖点，支持副卡共享、宽带融合，适合视频重度用户。</p>
+      </article>
+      <article class="card">
+        <h3>线上大众卡</h3>
+        <p>如「腾讯王卡」「阿里宝卡」等互联网合作产品，定向流量+会员权益组合灵活。</p>
+      </article>
+      <article class="card">
+        <h3>物联网/行业卡</h3>
+        <p>面向智慧交通、工业互联网场景，提供低功耗 NB-IoT 与 5G 行业模组。</p>
+      </article>
+    </section>
+
+    <section class="section-title">
+      <h2>网络与国际合作</h2>
+      <p>联通与中国电信共同建设 5G 网络，重点城市覆盖能力稳步提升，同时拓展国际漫游与港澳台合作。</p>
+    </section>
+    <section class="insight">
+      <strong>关键亮点</strong>
+      <ul>
+        <li>5G 共建共享基站数突破 100 万，重点覆盖京津冀、长三角、大湾区。</li>
+        <li>国际漫游覆盖 180+ 国家，推出港澳台、日本、韩国等热门目的地流量包。</li>
+        <li>「联通数科」赋能政企客户，提供云、物联网与安全一体化解决方案。</li>
+      </ul>
+    </section>
+
+    <section class="section-title">
+      <h2>办理流程与副卡策略</h2>
+      <p>联通强调线上线下一体化办理，并提供丰富的副卡管理工具满足家庭与企业需求。</p>
+    </section>
+    <section class="process">
+      <div class="process-step">
+        <strong>1. 线上选号/号卡寄送</strong>
+        <span>通过中国联通 APP、联通营业厅小程序选择号段，支持快递实名核身。</span>
+      </div>
+      <div class="process-step">
+        <strong>2. 线下核验激活</strong>
+        <span>持身份证件至营业厅或快递员上门完成实名，人脸核验通过后即可插卡使用。</span>
+      </div>
+      <div class="process-step">
+        <strong>3. 副卡与共享管理</strong>
+        <span>在「中国联通」APP 中开通副卡，设定流量/语音上限，支持家庭成员/员工共享套餐资源。</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>精选权益与增值服务</h2>
+      <p>面向家庭与企业用户提供内容、金融与安全等多元权益，提升用户黏性。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>内容合作</h3>
+        <ul>
+          <li>与腾讯、阿里、哔哩哔哩等平台联名推出定向流量。</li>
+          <li>沃视频、沃阅读等自有内容服务提供会员礼包。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>金融与福利</h3>
+        <ul>
+          <li>沃钱包支持话费分期、积分兑换、联名信用卡优惠。</li>
+          <li>提供境外上网保障、航旅合作及机场贵宾厅权益。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>企业解决方案</h3>
+        <ul>
+          <li>结合 5G MEC 与云主机，为制造、教育、医疗行业构建专网。</li>
+          <li>提供终端管控、MDM、统一计费等企业级服务。</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="faq">
+      <div class="faq-item">
+        <h3>副卡最多可以开通几张？</h3>
+        <p>根据不同套餐可开通 1-4 张副卡，主卡可在 APP 中设定副卡额度并实时查询使用情况。</p>
+      </div>
+      <div class="faq-item">
+        <h3>港澳台漫游如何办理？</h3>
+        <p>可提前在 APP 购买港澳台流量包，抵达后自动生效；若需实体 SIM，可在口岸营业厅办理联通大湾区卡。</p>
+      </div>
+      <div class="faq-item">
+        <h3>号码注销与保号</h3>
+        <p>长时间出国可申请「长期停机保号」，月费 5 元；需销户时请携证件至营业厅完成信息核验并清理欠费。</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    © Postcode Blog — 中国联通手机卡信息来源于中国联通官方公告、财务报告及工信部通信业统计公报。
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,75 @@
       flex-wrap: wrap;
       font-size: 0.95rem;
       font-weight: 500;
+      align-items: center;
+    }
+
+    .nav-item {
+      position: relative;
+    }
+
+    .nav-item > a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--text);
+    }
+
+    .nav-caret {
+      font-size: 0.7rem;
+      color: var(--muted);
+      transition: transform 0.2s ease;
+    }
+
+    .nav-item:hover .nav-caret,
+    .nav-item:focus-within .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .nav-item.active > a {
+      color: var(--primary);
+    }
+
+    .nav-item.active .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      left: 0;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.4);
+      padding: 1rem;
+      min-width: 200px;
+      border: 1px solid var(--border);
+      z-index: 10;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .dropdown a {
+      color: var(--text);
+      font-weight: 500;
+      transition: color 0.2s ease, transform 0.2s ease;
+    }
+
+    .dropdown a:hover {
+      color: var(--primary);
+      transform: translateX(4px);
+    }
+
+    .nav-item:hover .dropdown,
+    .nav-item:focus-within .dropdown {
+      display: flex;
+    }
+
+    .nav-item.active .dropdown {
+      display: flex;
     }
 
     main {
@@ -336,6 +405,14 @@
         <a href="/search/">Search Directory</a>
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
+        <div class="nav-item">
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="false">手机卡 <span class="nav-caret">▾</span></a>
+          <div class="dropdown" role="menu">
+            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
+            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
+            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+          </div>
+        </div>
       </div>
     </nav>
   </header>

--- a/mobile-sim-cards.html
+++ b/mobile-sim-cards.html
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>中国手机卡全指南｜覆盖、套餐、实名制与购买建议 - Postcode Blog</title>
+  <meta name="description" content="专业梳理中国手机卡办理攻略，涵盖中国电信、中国移动、中国联通网络覆盖、套餐资费、实名制要求、境外访客建议等核心信息，助您快速选择合适的SIM卡。">
+  <link rel="canonical" href="https://postcode.blog/mobile-sim-cards.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #2451ff;
+      --primary-dark: #1235c7;
+      --bg: #f5f7ff;
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --text: #0f172a;
+      --muted: #64748b;
+      --border: #e2e8f0;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #e4e9ff, #f6f8ff 60%);
+      color: var(--text);
+      line-height: 1.75;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    header {
+      background: rgba(255, 255, 255, 0.92);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .nav {
+      max-width: 1140px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .logo {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--primary);
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      font-size: 0.95rem;
+      font-weight: 500;
+      align-items: center;
+    }
+
+    .nav-links > a {
+      color: var(--text);
+    }
+
+    .nav-item {
+      position: relative;
+    }
+
+    .nav-item > a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--text);
+    }
+
+    .nav-caret {
+      font-size: 0.7rem;
+      color: var(--muted);
+      transition: transform 0.2s ease;
+    }
+
+    .nav-item:hover .nav-caret,
+    .nav-item:focus-within .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .nav-item.active > a {
+      color: var(--primary);
+    }
+
+    .nav-item.active .nav-caret {
+      transform: rotate(180deg);
+      color: var(--primary);
+    }
+
+    .dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      left: 0;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 24px 48px -20px rgba(15, 23, 42, 0.4);
+      padding: 1rem;
+      min-width: 220px;
+      border: 1px solid var(--border);
+      z-index: 10;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .dropdown a {
+      color: var(--text);
+      font-weight: 500;
+      transition: color 0.2s ease, transform 0.2s ease;
+    }
+
+    .dropdown a:hover {
+      color: var(--primary);
+      transform: translateX(4px);
+    }
+
+    .nav-item:hover .dropdown,
+    .nav-item:focus-within .dropdown {
+      display: flex;
+    }
+
+    .nav-item.active .dropdown {
+      display: flex;
+    }
+
+    .dropdown a[aria-current="page"] {
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    main {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 3.5rem 1.5rem 5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 3.5rem;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, #244dff 0%, #6888ff 100%);
+      border-radius: 32px;
+      color: #fff;
+      padding: 3rem;
+      box-shadow: 0 32px 60px -30px rgba(36, 77, 255, 0.6);
+      overflow: hidden;
+    }
+
+    .hero h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.4rem, 5vw, 3.4rem);
+      letter-spacing: -0.02em;
+    }
+
+    .hero p {
+      max-width: 640px;
+      margin: 0 0 2rem;
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 1.1rem;
+    }
+
+    .badge-row {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .badge {
+      background: rgba(255, 255, 255, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.45);
+      color: #fff;
+      padding: 0.55rem 1rem;
+      border-radius: 999px;
+      font-weight: 500;
+      font-size: 0.9rem;
+      letter-spacing: 0.02em;
+    }
+
+    section.card-grid {
+      display: grid;
+      gap: 1.8rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 1.8rem;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      box-shadow: 0 16px 45px -24px rgba(15, 23, 42, 0.45);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 1.25rem;
+    }
+
+    .card ul {
+      margin: 0;
+      padding-left: 1.2rem;
+      color: var(--muted);
+    }
+
+    .card ul li {
+      margin-bottom: 0.6rem;
+    }
+
+    .section-title {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: 2rem;
+    }
+
+    .section-title p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--card-bg);
+      border-radius: 24px;
+      overflow: hidden;
+      box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.5);
+    }
+
+    .comparison-table thead {
+      background: #eff3ff;
+      color: var(--primary-dark);
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      padding: 1.2rem 1.4rem;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+    }
+
+    .comparison-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 1.4rem;
+    }
+
+    .timeline-item {
+      display: grid;
+      gap: 0.35rem;
+      padding: 1.4rem 1.6rem;
+      background: var(--card-bg);
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      box-shadow: 0 16px 40px -28px rgba(15, 23, 42, 0.4);
+    }
+
+    .timeline-item strong {
+      font-size: 1.05rem;
+    }
+
+    .faq {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .faq-item {
+      background: var(--card-bg);
+      border-radius: 20px;
+      padding: 1.5rem;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      box-shadow: 0 12px 32px -26px rgba(15, 23, 42, 0.4);
+    }
+
+    .faq-item h3 {
+      margin: 0 0 0.75rem;
+      font-size: 1.1rem;
+    }
+
+    footer {
+      padding: 3rem 1.5rem 4rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 720px) {
+      .hero {
+        padding: 2.4rem 2rem;
+      }
+
+      .comparison-table th,
+      .comparison-table td {
+        padding: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <a class="logo" href="/">Postcode Blog</a>
+      <div class="nav-links">
+        <a href="/finder/">Finder</a>
+        <a href="/lookup/">Lookup</a>
+        <a href="/search/">Search Directory</a>
+        <a href="/cities/">A–Z Cities</a>
+        <a href="/faq/">FAQ</a>
+        <div class="nav-item active">
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <div class="dropdown" role="menu">
+            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
+            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
+            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>中国手机卡权威全指南</h1>
+      <p>从网络覆盖、资费体系到实名制政策与境外访客办理路径，全面梳理中国电信、中国移动、中国联通三大运营商的手机卡解决方案，为政企客户、长期居住者及短期旅客提供可落地的选择建议。</p>
+      <div class="badge-row">
+        <span class="badge">5G/4G网络覆盖分析</span>
+        <span class="badge">实名制与证件要求</span>
+        <span class="badge">境外访客专属方案</span>
+        <span class="badge">套餐组合建议</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>三大运营商核心对比</h2>
+      <p>依据工业和信息化部公开数据、运营商年报以及市场调研资料，总结中国电信、中国移动、中国联通在网络资源、用户规模、国际漫游与客服支持方面的差异，为您提供决策参考。</p>
+    </section>
+    <section>
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>维度</th>
+            <th>中国电信</th>
+            <th>中国移动</th>
+            <th>中国联通</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>5G基站及覆盖</td>
+            <td>深耕中高端5G，城市室内覆盖出色，提供千兆光宽融合服务。</td>
+            <td>基站数量领先，县域覆盖广，语音通话稳定性强。</td>
+            <td>5G共建共享策略推动重点城市覆盖，注重行业应用。</td>
+          </tr>
+          <tr>
+            <td>套餐体系</td>
+            <td>天翼5G、畅享套餐组合灵活，强调云存储与权益。</td>
+            <td>全球通、移动花卡等类型多样，新媒体权益丰富。</td>
+            <td>联通5G、冰激凌套餐突出流量大额与副卡能力。</td>
+          </tr>
+          <tr>
+            <td>国际服务</td>
+            <td>面向商务人士推出全球卡与eSIM，国际通话资费优惠。</td>
+            <td>国际漫游覆盖180+国家，流量包选择多。</td>
+            <td>跨境数据合作突出港澳台、日本、东南亚市场。</td>
+          </tr>
+          <tr>
+            <td>适合人群</td>
+            <td>注重家庭融合、宽带+云服务的用户。</td>
+            <td>需要全国广覆盖与语音可靠性的个人与企业。</td>
+            <td>追求高性价比与灵活副卡管理的年轻用户。</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section-title">
+      <h2>办理手机卡前的关键核查清单</h2>
+      <p>结合三大运营商统一的实名制监管要求，总结办理流程的关键节点，确保您能够快速完成开户并符合监管要求。</p>
+    </section>
+    <section class="timeline">
+      <div class="timeline-item">
+        <strong>1. 证件准备</strong>
+        <span>中国大陆居民提供居民身份证；港澳台居民提供《港澳居民居住证》或《台湾居民居住证》；外籍人士需持护照及入境签证/居留许可。</span>
+      </div>
+      <div class="timeline-item">
+        <strong>2. 预选套餐</strong>
+        <span>根据使用时长与流量需求确定月租档位。若为短期访客，可关注「随用随充」或「预付费」套餐，避免押金压力。</span>
+      </div>
+      <div class="timeline-item">
+        <strong>3. 实名登记与人脸核验</strong>
+        <span>营业厅现场拍照、刷证或通过官方App远程实名，完成公安联网校验后方可开通。</span>
+      </div>
+      <div class="timeline-item">
+        <strong>4. 激活与测试</strong>
+        <span>装卡后开机激活，拨打客服热线（10000/10086/10010）验证语音通话，同时测试数据网络、漫游及5G信号。</span>
+      </div>
+    </section>
+
+    <section class="section-title">
+      <h2>境外访客办理建议</h2>
+      <p>短期访华人员可选择机场/火车站营业点或认证旅行社。多数城市提供英文服务窗口，亦支持护照+入境章办理。</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3>快速办理渠道</h3>
+        <ul>
+          <li>中国移动、联通在主要国际机场设有「旅客服务柜台」。</li>
+          <li>部分省市支持线上预约，抵达后凭预约码快速领取。</li>
+          <li>若停留不足30天，可购买运营商推出的短期旅游卡。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>支付与充值</h3>
+        <ul>
+          <li>支持现金、银联卡及主流移动支付（支付宝、微信支付）。</li>
+          <li>可在便利店、官网或移动App完成充值，境外用户亦可使用国际信用卡。</li>
+          <li>建议开启短信账单提醒，关注余额与有效期。</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>数据安全与合规</h3>
+        <ul>
+          <li>实名信息仅用于电信监管备案，运营商遵循国家数据安全法。</li>
+          <li>如需注销号码，可通过官方App或营业厅办理，确保个人信息及时清除。</li>
+          <li>长时间停用请办理保号或销户，避免欠费影响个人信用。</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="section-title">
+      <h2>更多阅读</h2>
+      <p>深入了解各运营商手机卡方案，获取针对性套餐与服务建议：</p>
+    </section>
+    <section class="card-grid">
+      <article class="card">
+        <h3><a href="/china-telecom-sim.html">中国电信手机卡</a></h3>
+        <p>聚焦政企与家庭融合场景，了解天翼5G、星卡、融合套餐亮点。</p>
+      </article>
+      <article class="card">
+        <h3><a href="/china-mobile-sim.html">中国移动手机卡</a></h3>
+        <p>探索全球通、5G智享、移动花卡等大众化方案与权益。</p>
+      </article>
+      <article class="card">
+        <h3><a href="/china-unicom-sim.html">中国联通手机卡</a></h3>
+        <p>掌握联通5G、冰激凌、副卡共享等高性价比组合。</p>
+      </article>
+    </section>
+  </main>
+  <footer>
+    © Postcode Blog 提供的中国通信服务指南，数据参考工信部《通信业统计公报》及运营商官方公告。
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dropdown navigation item on the homepage that links to new SIM card resources
- create a flagship Chinese SIM card landing page with coverage, compliance, and visitor guidance
- publish individual guides for China Telecom, China Mobile, and China Unicom mobile SIM offerings

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e70df2cf588321833f67bded2c9dd4