### PR TITLE
Translate SIM navigation labels to English

### DIFF
--- a/china-mobile-sim.html
+++ b/china-mobile-sim.html
@@ -318,11 +318,11 @@
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item active">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">Mobile SIM Cards <span class="nav-caret">▾</span></a>
           <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
-            <a href="/china-mobile-sim.html" role="menuitem" aria-current="page">中国移动手机卡</a>
-            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+            <a href="/china-telecom-sim.html" role="menuitem">China Telecom SIM Cards</a>
+            <a href="/china-mobile-sim.html" role="menuitem" aria-current="page">China Mobile SIM Cards</a>
+            <a href="/china-unicom-sim.html" role="menuitem">China Unicom SIM Cards</a>
           </div>
         </div>
       </div>

--- a/china-telecom-sim.html
+++ b/china-telecom-sim.html
@@ -318,11 +318,11 @@
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item active">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">Mobile SIM Cards <span class="nav-caret">▾</span></a>
           <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem" aria-current="page">中国电信手机卡</a>
-            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
-            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+            <a href="/china-telecom-sim.html" role="menuitem" aria-current="page">China Telecom SIM Cards</a>
+            <a href="/china-mobile-sim.html" role="menuitem">China Mobile SIM Cards</a>
+            <a href="/china-unicom-sim.html" role="menuitem">China Unicom SIM Cards</a>
           </div>
         </div>
       </div>

--- a/china-unicom-sim.html
+++ b/china-unicom-sim.html
@@ -318,11 +318,11 @@
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item active">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">Mobile SIM Cards <span class="nav-caret">▾</span></a>
           <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
-            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
-            <a href="/china-unicom-sim.html" role="menuitem" aria-current="page">中国联通手机卡</a>
+            <a href="/china-telecom-sim.html" role="menuitem">China Telecom SIM Cards</a>
+            <a href="/china-mobile-sim.html" role="menuitem">China Mobile SIM Cards</a>
+            <a href="/china-unicom-sim.html" role="menuitem" aria-current="page">China Unicom SIM Cards</a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -469,11 +469,11 @@
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="false">手机卡 <span class="nav-caret">▾</span></a>
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="false">Mobile SIM Cards <span class="nav-caret">▾</span></a>
           <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
-            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
-            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+            <a href="/china-telecom-sim.html" role="menuitem">China Telecom SIM Cards</a>
+            <a href="/china-mobile-sim.html" role="menuitem">China Mobile SIM Cards</a>
+            <a href="/china-unicom-sim.html" role="menuitem">China Unicom SIM Cards</a>
           </div>
         </div>
       </div>

--- a/mobile-sim-cards.html
+++ b/mobile-sim-cards.html
@@ -337,11 +337,11 @@
         <a href="/cities/">A–Z Cities</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item active">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">手机卡 <span class="nav-caret">▾</span></a>
+          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="true">Mobile SIM Cards <span class="nav-caret">▾</span></a>
           <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem">中国电信手机卡</a>
-            <a href="/china-mobile-sim.html" role="menuitem">中国移动手机卡</a>
-            <a href="/china-unicom-sim.html" role="menuitem">中国联通手机卡</a>
+            <a href="/china-telecom-sim.html" role="menuitem">China Telecom SIM Cards</a>
+            <a href="/china-mobile-sim.html" role="menuitem">China Mobile SIM Cards</a>
+            <a href="/china-unicom-sim.html" role="menuitem">China Unicom SIM Cards</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the homepage SIM navigation label and dropdown entries to English
- align the SIM navigation wording across the carrier detail pages with the new English labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9b0b85b948321a90a7da617ae7b0a