### PR TITLE
Add AI tools link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,7 @@
         <a href="/us-zip-codes.html">US ZIP Codes</a>
         <a href="/cities/">A–Z Cities</a>
         <a href="/hotel-directory.html">Hotel Directory</a>
+        <a href="https://seodog.cn/" target="_blank" rel="noopener">AI tools</a>
         <a href="/faq/">FAQ</a>
         <div class="nav-item">
           <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="false">Mobile SIM Cards <span class="nav-caret">▾</span></a>


### PR DESCRIPTION
## Summary
- add an external AI tools link to the homepage navigation bar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902e48c98908321a619995b50a96cd5