### PR TITLE
Hide Mobile SIM menu from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,14 +472,6 @@
         <a href="/hotel-directory.html">Hotel Directory</a>
         <a href="https://seodog.cn/" target="_blank" rel="noopener">AI tools</a>
         <a href="/faq/">FAQ</a>
-        <div class="nav-item">
-          <a href="/mobile-sim-cards.html" aria-haspopup="true" aria-expanded="false">Mobile SIM Cards <span class="nav-caret">▾</span></a>
-          <div class="dropdown" role="menu">
-            <a href="/china-telecom-sim.html" role="menuitem">China Telecom SIM Cards</a>
-            <a href="/china-mobile-sim.html" role="menuitem">China Mobile SIM Cards</a>
-            <a href="/china-unicom-sim.html" role="menuitem">China Unicom SIM Cards</a>
-          </div>
-        </div>
       </div>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- remove the Mobile SIM Cards dropdown from the homepage navigation to hide the menu entry

## Testing
- not run (static HTML change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691adc9cd6908321b60354c39f1ab449)