### PR TITLE
Move major city postal codes block to top of homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,35 +584,6 @@
     </nav>
   </header>
   <main>
-    <section class="search-block" aria-labelledby="postal-search">
-      <div class="hero">
-        <div class="section-header">
-          <div>
-            <h1 id="postal-search">China postal code (zip code) lookup</h1>
-            <p>Find verified six-digit postcodes for every province, city, and district. Our directory is refreshed with the latest China Post data so your parcels and hotel bookings never miss the mark.</p>
-          </div>
-        </div>
-        <div class="stat-badges">
-          <span class="badge"><strong>34</strong> province hubs</span>
-          <span class="badge"><strong>600+</strong> city pages</span>
-          <span class="badge"><strong>100k+</strong> searchable entries</span>
-          <span class="badge">Bilingual search (中 / EN)</span>
-        </div>
-      </div>
-      <form class="search-form" role="search" action="/search/" method="get">
-        <label class="sr-only" for="postal-search-input">Postal code search</label>
-        <div class="search-input-wrap">
-          <input class="search-input" id="postal-search-input" name="q" type="search" placeholder="e.g. Beijing 100000, Futian district, 200120" autocomplete="postal-code">
-          <button class="search-submit" type="submit">Search</button>
-        </div>
-        <p class="search-help">Supports Chinese and English keywords like “上海 邮政编码” or “Guangzhou 510000”.</p>
-        <div class="search-meta">
-          <span>Tip: paste any full or partial address to get province → city → district matches.</span>
-          <span>Coverage: mainland China, SARs (Hong Kong, Macau), Taiwan, plus US ZIP code reference.</span>
-        </div>
-      </form>
-    </section>
-
     <section aria-labelledby="major-city-codes">
       <div class="major-cities-block">
         <div>
@@ -718,24 +689,7 @@
               </div>
               <div>
                 <dt>Full guide</dt>
-                <dd><a href="/search/?q=杭州 邮政编码">Hangzhou postcode reference</a></dd>
-              </div>
-            </dl>
-          </article>
-          <article class="city-info">
-            <header>
-              <h3>Wuhan <span class="local-name">武汉</span></h3>
-              <p class="postcode">430000</p>
-            </header>
-            <p>Serves Hankou Riverfront, Jiang’an, and central Zhongnan Road.</p>
-            <dl class="city-meta">
-              <div>
-                <dt>Key districts</dt>
-                <dd>Jianghan · Wuchang · Hongshan · Hanyang</dd>
-              </div>
-              <div>
-                <dt>Full guide</dt>
-                <dd><a href="/search/?q=武汉 邮政编码">Wuhan postal codes</a></dd>
+                <dd><a href="/city/hangzhou/">Hangzhou district postcodes</a></dd>
               </div>
             </dl>
           </article>
@@ -744,15 +698,32 @@
               <h3>Xi’an <span class="local-name">西安</span></h3>
               <p class="postcode">710000</p>
             </header>
-            <p>Historic center including Bell Tower, Beilin, and City Wall areas.</p>
+            <p>Downtown Bell Tower, Beilin, and city wall tourism belt.</p>
             <dl class="city-meta">
               <div>
                 <dt>Key districts</dt>
-                <dd>Xincheng · Beilin · Yanta · Weiyang</dd>
+                <dd>Yanta · Beilin · Weiyang · Lianhu</dd>
               </div>
               <div>
                 <dt>Full guide</dt>
-                <dd><a href="/search/?q=西安 邮政编码">Xi’an postcode list</a></dd>
+                <dd><a href="/city/xian/">Xi’an postcode finder</a></dd>
+              </div>
+            </dl>
+          </article>
+          <article class="city-info">
+            <header>
+              <h3>Wuhan <span class="local-name">武汉</span></h3>
+              <p class="postcode">430000</p>
+            </header>
+            <p>Yangtze riverfront, Hankou business district, and university town.</p>
+            <dl class="city-meta">
+              <div>
+                <dt>Key districts</dt>
+                <dd>Jiang’an · Wuchang · Hongshan · Qiaokou</dd>
+              </div>
+              <div>
+                <dt>Full guide</dt>
+                <dd><a href="/city/wuhan/">Wuhan postal directory</a></dd>
               </div>
             </dl>
           </article>
@@ -761,21 +732,86 @@
               <h3>Chongqing <span class="local-name">重庆</span></h3>
               <p class="postcode">400000</p>
             </header>
-            <p>Yuzhong peninsula, Jiefangbei, and Lianglukou transit hub.</p>
+            <p>Yuzhong CBD, Liberation Monument, and rail transit hub.</p>
             <dl class="city-meta">
               <div>
                 <dt>Key districts</dt>
-                <dd>Yuzhong · Jiangbei · Nan’an · Shapingba</dd>
+                <dd>Yuzhong · Jiangbei · Shapingba · Nanan</dd>
               </div>
               <div>
                 <dt>Full guide</dt>
-                <dd><a href="/search/?q=重庆 邮政编码">Chongqing postal guide</a></dd>
+                <dd><a href="/city/chongqing/">Chongqing postal code search</a></dd>
+              </div>
+            </dl>
+          </article>
+          <article class="city-info">
+            <header>
+              <h3>Nanjing <span class="local-name">南京</span></h3>
+              <p class="postcode">210000</p>
+            </header>
+            <p>Presidential Palace area, Xinjiekou, and Confucius Temple visits.</p>
+            <dl class="city-meta">
+              <div>
+                <dt>Key districts</dt>
+                <dd>Xuanwu · Qinhuai · Jianye · Gulou</dd>
+              </div>
+              <div>
+                <dt>Full guide</dt>
+                <dd><a href="/city/nanjing/">Nanjing postcode map</a></dd>
+              </div>
+            </dl>
+          </article>
+          <article class="city-info">
+            <header>
+              <h3>Changsha <span class="local-name">长沙</span></h3>
+              <p class="postcode">410000</p>
+            </header>
+            <p>Yuelu Mountain, Orange Island, and Taiping Street classics.</p>
+            <dl class="city-meta">
+              <div>
+                <dt>Key districts</dt>
+                <dd>Furong · Yuelu · Kaifu · Tianxin</dd>
+              </div>
+              <div>
+                <dt>Full guide</dt>
+                <dd><a href="/city/changsha/">Changsha postal index</a></dd>
               </div>
             </dl>
           </article>
         </div>
       </div>
     </section>
+
+    <section class="search-block" aria-labelledby="postal-search">
+      <div class="hero">
+        <div class="section-header">
+          <div>
+            <h1 id="postal-search">China postal code (zip code) lookup</h1>
+            <p>Find verified six-digit postcodes for every province, city, and district. Our directory is refreshed with the latest China Post data so your parcels and hotel bookings never miss the mark.</p>
+          </div>
+        </div>
+        <div class="stat-badges">
+          <span class="badge"><strong>34</strong> province hubs</span>
+          <span class="badge"><strong>600+</strong> city pages</span>
+          <span class="badge"><strong>100k+</strong> searchable entries</span>
+          <span class="badge">Bilingual search (中 / EN)</span>
+        </div>
+      </div>
+      <form class="search-form" role="search" action="/search/" method="get">
+        <label class="sr-only" for="postal-search-input">Postal code search</label>
+        <div class="search-input-wrap">
+          <input class="search-input" id="postal-search-input" name="q" type="search" placeholder="e.g. Beijing 100000, Futian district, 200120" autocomplete="postal-code">
+          <button class="search-submit" type="submit">Search</button>
+        </div>
+        <p class="search-help">Supports Chinese and English keywords like “上海 邮政编码” or “Guangzhou 510000”.</p>
+        <div class="search-meta">
+          <span>Tip: paste any full or partial address to get province → city → district matches.</span>
+          <span>Coverage: mainland China, SARs (Hong Kong, Macau), Taiwan, plus US ZIP code reference.</span>
+        </div>
+      </form>
+    </section>
+
+    
 
     <section aria-labelledby="popular-cities">
       <div class="section-header">


### PR DESCRIPTION
## Summary
- move the "China major city postal codes" block to the top of the homepage for greater visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bba299f3883219541d79ac9b3e7fe)