### PR TITLE
Add Chinese postcode landing pages and guides

### DIFF
--- a/city/beijing/youbian.html
+++ b/city/beijing/youbian.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>北京邮编大全｜北京各区6位邮政编码一览</title>
+  <meta name="description" content="北京邮编大全：朝阳、海淀、东城、西城、丰台、通州等重点城区6位邮政编码及查询指南，附邮编规则与使用技巧。">
+  <link rel="canonical" href="https://postcode.blog/city/beijing/youbian.html">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="北京邮编大全｜北京各区6位邮政编码一览">
+  <meta property="og:description" content="北京主要城区邮编一览，含查询方法、常见问题与邮寄格式。">
+  <meta property="og:url" content="https://postcode.blog/city/beijing/youbian.html">
+  <meta property="og:site_name" content="Postcode Blog">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="北京邮编大全｜北京各区6位邮政编码一览">
+  <meta name="twitter:description" content="北京主要城区邮编一览，含查询方法、常见问题与邮寄格式。">
+  <style>
+    body {font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif; margin: 0; padding: 0; background: #f7f9fb; color: #0f172a; line-height: 1.7;}
+    header, main {max-width: 960px; margin: auto; padding: 24px;}
+    h1 {font-size: 32px; margin-bottom: 8px;}
+    h2 {margin-top: 32px; font-size: 24px;}
+    p {margin: 12px 0;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; box-shadow: 0 6px 30px rgba(15,23,42,0.05);} 
+    .grid {display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px;}
+    table {width: 100%; border-collapse: collapse; margin-top: 12px;}
+    th, td {padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left;}
+    th {background: #f1f5f9; font-weight: 600;}
+    .badge {display: inline-block; padding: 6px 10px; border-radius: 999px; background: #e0e7ff; color: #1d4ed8; font-weight: 600; font-size: 12px; margin-right: 8px;}
+    .cta {display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; background: #1f4bff; color: #fff; border-radius: 10px; text-decoration: none; font-weight: 600;}
+    .cta:hover {background: #1434b8;}
+    ul {padding-left: 20px;}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Postcode Blog · 北京邮编查询",
+    "description": "北京邮编大全，覆盖朝阳、海淀、东城、西城等城区，提供6位邮政编码与查询提示。",
+    "url": "https://postcode.blog/city/beijing/youbian.html",
+    "areaServed": {
+      "@type": "City",
+      "name": "北京市"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "北京市",
+      "addressCountry": "CN",
+      "postalCode": "100000"
+    },
+    "sameAs": [
+      "https://postcode.blog/city/beijing/"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="badge">北京邮编</p>
+    <h1>北京邮编大全</h1>
+    <p>按城区整理的北京邮政编码，涵盖常用6位数字格式及寄件填写示例。想查询更细的街道/小区，可直接使用 <a href="https://postcode.blog/finder/" target="_blank" rel="noopener">邮编查找器</a> 搜索。</p>
+    <a class="cta" href="https://postcode.blog/city/beijing/">查看英文版北京邮编索引</a>
+  </header>
+  <main class="grid">
+    <section class="card">
+      <h2>热门城区邮编</h2>
+      <p>以下为常见行政区的主干邮编，适合填写快递、证件申请或地址验证。街道级别可能存在分段编码，请在寄出前确认详细地址。</p>
+      <table>
+        <thead><tr><th>城区</th><th>主邮编</th><th>备注</th></tr></thead>
+        <tbody>
+          <tr><td>东城区</td><td>100010</td><td>天安门、王府井、东直门周边</td></tr>
+          <tr><td>西城区</td><td>100032</td><td>西单、金融街、复兴门周边</td></tr>
+          <tr><td>朝阳区</td><td>100020</td><td>国贸、三里屯、望京等商圈</td></tr>
+          <tr><td>海淀区</td><td>100080</td><td>中关村、五道口、学院路</td></tr>
+          <tr><td>丰台区</td><td>100071</td><td>总部基地、草桥、丽泽</td></tr>
+          <tr><td>石景山区</td><td>100043</td><td>古城、苹果园、八角</td></tr>
+          <tr><td>通州区</td><td>101100</td><td>万达、梨园、台湖</td></tr>
+          <tr><td>昌平区</td><td>102200</td><td>天通苑、沙河、回龙观</td></tr>
+          <tr><td>大兴区</td><td>102600</td><td>亦庄、新宫、黄村</td></tr>
+          <tr><td>顺义区</td><td>101300</td><td>后沙峪、天竺、马坡</td></tr>
+          <tr><td>房山区</td><td>102400</td><td>良乡、燕山、窦店</td></tr>
+          <tr><td>门头沟区</td><td>102300</td><td>城子、永定、潭柘寺</td></tr>
+          <tr><td>怀柔区</td><td>101400</td><td>雁栖湖、庙城、杨宋</td></tr>
+          <tr><td>平谷区</td><td>101200</td><td>金海湖、兴谷、滨河</td></tr>
+          <tr><td>密云区</td><td>101500</td><td>古北口、溪翁庄</td></tr>
+          <tr><td>延庆区</td><td>102100</td><td>八达岭、康庄、张山营</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="card">
+      <h2>邮编怎么查？</h2>
+      <ul>
+        <li>确认地址：按“区-街道-小区/楼宇”顺序写明，并保留地标。</li>
+        <li>使用查找器：在 <a href="https://postcode.blog/finder/">postcode.blog/finder</a> 输入中文或英文地址即可返回匹配邮编。</li>
+        <li>对照格式：北京邮编均为 6 位数字，如 <strong>100020</strong>，填写时避免添加空格或符号。</li>
+        <li>快递填写：放在收件人电话后或地址末尾，例如“北京市朝阳区建国路88号100020”。</li>
+      </ul>
+      <p>更多细节可参考《<a href="https://postcode.blog/youbian-zenme-cha.html">邮编怎么查</a>》专题。</p>
+      <h2>常见问题</h2>
+      <ul>
+        <li><strong>地址有多个邮编怎么办？</strong> 核对最近的街道/社区名称，优先使用与街道匹配的编码。</li>
+        <li><strong>乡镇地址如何填写？</strong> 首选所在镇的邮编，若不确定可拨打当地邮政或快递客服确认。</li>
+        <li><strong>格式会随行政区划调整吗？</strong> 6 位数字格式保持不变，个别新区可能更新末两位。</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/city/shanghai/youbian.html
+++ b/city/shanghai/youbian.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>上海邮编大全｜浦东、徐汇、静安等主要城区邮政编码</title>
+  <meta name="description" content="上海邮编大全：浦东、黄浦、徐汇、静安、闵行、宝山等热门区域6位邮政编码，含邮编查询方法与填写技巧。">
+  <link rel="canonical" href="https://postcode.blog/city/shanghai/youbian.html">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="上海邮编大全｜浦东、徐汇、静安等主要城区邮政编码">
+  <meta property="og:description" content="上海16个区常用邮政编码列表，以及邮编查询、格式和寄件示例。">
+  <meta property="og:url" content="https://postcode.blog/city/shanghai/youbian.html">
+  <meta property="og:site_name" content="Postcode Blog">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="上海邮编大全｜浦东、徐汇、静安等主要城区邮政编码">
+  <meta name="twitter:description" content="上海16个区常用邮政编码列表，以及邮编查询、格式和寄件示例。">
+  <style>
+    body {font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif; margin: 0; padding: 0; background: #f7f9fb; color: #0f172a; line-height: 1.7;}
+    header, main {max-width: 960px; margin: auto; padding: 24px;}
+    h1 {font-size: 32px; margin-bottom: 8px;}
+    h2 {margin-top: 32px; font-size: 24px;}
+    p {margin: 12px 0;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; box-shadow: 0 6px 30px rgba(15,23,42,0.05);} 
+    .grid {display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px;}
+    table {width: 100%; border-collapse: collapse; margin-top: 12px;}
+    th, td {padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left;}
+    th {background: #f1f5f9; font-weight: 600;}
+    .badge {display: inline-block; padding: 6px 10px; border-radius: 999px; background: #e0e7ff; color: #1d4ed8; font-weight: 600; font-size: 12px; margin-right: 8px;}
+    .cta {display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; background: #1f4bff; color: #fff; border-radius: 10px; text-decoration: none; font-weight: 600;}
+    .cta:hover {background: #1434b8;}
+    ul {padding-left: 20px;}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Postcode Blog · 上海邮编查询",
+    "description": "上海邮编大全，覆盖浦东、黄浦、徐汇、静安等城区，提供6位邮政编码与查询提示。",
+    "url": "https://postcode.blog/city/shanghai/youbian.html",
+    "areaServed": {
+      "@type": "City",
+      "name": "上海市"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "上海市",
+      "addressCountry": "CN",
+      "postalCode": "200000"
+    },
+    "sameAs": [
+      "https://postcode.blog/city/shanghai/"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="badge">上海邮编</p>
+    <h1>上海邮编大全</h1>
+    <p>快速查看上海16个行政区的主邮政编码，并了解如何填写快递单与网上表单。需要更精确的街道邮编可直接进入 <a href="https://postcode.blog/finder/" target="_blank" rel="noopener">邮编查找器</a>。</p>
+    <a class="cta" href="https://postcode.blog/city/shanghai/">查看英文版上海邮编索引</a>
+  </header>
+  <main class="grid">
+    <section class="card">
+      <h2>上海主要城区邮编</h2>
+      <table>
+        <thead><tr><th>城区</th><th>主邮编</th><th>备注</th></tr></thead>
+        <tbody>
+          <tr><td>黄浦区</td><td>200001</td><td>外滩、南京东路、小东门</td></tr>
+          <tr><td>徐汇区</td><td>200030</td><td>徐家汇、漕河泾、衡山路</td></tr>
+          <tr><td>长宁区</td><td>200050</td><td>中山公园、天山路</td></tr>
+          <tr><td>静安区</td><td>200040</td><td>南京西路、静安寺</td></tr>
+          <tr><td>普陀区</td><td>200333</td><td>真如、长寿路、桃浦</td></tr>
+          <tr><td>虹口区</td><td>200080</td><td>北外滩、曲阳路</td></tr>
+          <tr><td>杨浦区</td><td>200082</td><td>五角场、同济大学</td></tr>
+          <tr><td>浦东新区</td><td>200120</td><td>陆家嘴、张江、花木</td></tr>
+          <tr><td>闵行区</td><td>201100</td><td>莘庄、七宝、虹桥镇</td></tr>
+          <tr><td>宝山区</td><td>201900</td><td>淞南、顾村、大学城</td></tr>
+          <tr><td>嘉定区</td><td>201800</td><td>嘉定新城、安亭、江桥</td></tr>
+          <tr><td>松江区</td><td>201600</td><td>大学城、广富林、九亭</td></tr>
+          <tr><td>青浦区</td><td>201700</td><td>徐泾、朱家角</td></tr>
+          <tr><td>奉贤区</td><td>201400</td><td>南桥镇、金汇</td></tr>
+          <tr><td>金山区</td><td>201500</td><td>石化、枫泾、朱泾</td></tr>
+          <tr><td>崇明区</td><td>202150</td><td>城桥、东滩</td></tr>
+        </tbody>
+      </table>
+      <p>上海邮编均为 200xxx 或 201xxx 开头，填写收件地址时记得放在末尾，如“上海市浦东新区世纪大道100号 200120”。</p>
+    </section>
+    <section class="card">
+      <h2>查询与填写提示</h2>
+      <ul>
+        <li>想核对街道/园区级编码，推荐使用 <a href="https://postcode.blog/finder/">邮编查找器</a> 直接搜索中文地址。</li>
+        <li>跨境购物或寄件时，上海地址通常需要全英文，邮编保持 6 位数字即可。</li>
+        <li>遇到新楼盘可先填所在街道的主邮编，或咨询快递客服确认最新编码。</li>
+        <li>更多技巧可参考《<a href="https://postcode.blog/youbian-zenme-cha.html">邮编怎么查</a>》及《<a href="https://postcode.blog/youbian-guize.html">邮编规则</a>》。</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/city/shenzhen/youbian.html
+++ b/city/shenzhen/youbian.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>深圳邮编大全｜福田、南山、龙华等区域邮政编码</title>
+  <meta name="description" content="深圳邮编大全：福田、罗湖、南山、宝安、龙岗、龙华、光明、坪山、大鹏、盐田等区域6位邮政编码及填写要点。">
+  <link rel="canonical" href="https://postcode.blog/city/shenzhen/youbian.html">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="深圳邮编大全｜福田、南山、龙华等区域邮政编码">
+  <meta property="og:description" content="深圳各区邮政编码整理，附邮编查询方法与跨境电商填写示例。">
+  <meta property="og:url" content="https://postcode.blog/city/shenzhen/youbian.html">
+  <meta property="og:site_name" content="Postcode Blog">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="深圳邮编大全｜福田、南山、龙华等区域邮政编码">
+  <meta name="twitter:description" content="深圳各区邮政编码整理，附邮编查询方法与跨境电商填写示例。">
+  <style>
+    body {font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif; margin: 0; padding: 0; background: #f7f9fb; color: #0f172a; line-height: 1.7;}
+    header, main {max-width: 960px; margin: auto; padding: 24px;}
+    h1 {font-size: 32px; margin-bottom: 8px;}
+    h2 {margin-top: 32px; font-size: 24px;}
+    p {margin: 12px 0;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; box-shadow: 0 6px 30px rgba(15,23,42,0.05);} 
+    .grid {display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px;}
+    table {width: 100%; border-collapse: collapse; margin-top: 12px;}
+    th, td {padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left;}
+    th {background: #f1f5f9; font-weight: 600;}
+    .badge {display: inline-block; padding: 6px 10px; border-radius: 999px; background: #e0e7ff; color: #1d4ed8; font-weight: 600; font-size: 12px; margin-right: 8px;}
+    .cta {display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; background: #1f4bff; color: #fff; border-radius: 10px; text-decoration: none; font-weight: 600;}
+    .cta:hover {background: #1434b8;}
+    ul {padding-left: 20px;}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Postcode Blog · 深圳邮编查询",
+    "description": "深圳邮编大全，覆盖福田、南山、宝安、龙岗等区域，提供6位邮政编码与查询提示。",
+    "url": "https://postcode.blog/city/shenzhen/youbian.html",
+    "areaServed": {
+      "@type": "City",
+      "name": "深圳市"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "深圳市",
+      "addressCountry": "CN",
+      "postalCode": "518000"
+    },
+    "sameAs": [
+      "https://postcode.blog/city/shenzhen/"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="badge">深圳邮编</p>
+    <h1>深圳邮编大全</h1>
+    <p>为跨境电商、港澳通勤与商务寄件整理的深圳邮编指南。想查找园区或社区级邮编，可直接访问 <a href="https://postcode.blog/finder/" target="_blank" rel="noopener">邮编查找器</a> 输入中文地址。</p>
+    <a class="cta" href="https://postcode.blog/city/shenzhen/">查看英文版深圳邮编索引</a>
+  </header>
+  <main class="grid">
+    <section class="card">
+      <h2>深圳各区邮政编码</h2>
+      <table>
+        <thead><tr><th>城区</th><th>主邮编</th><th>备注</th></tr></thead>
+        <tbody>
+          <tr><td>福田区</td><td>518033</td><td>中心区、车公庙、福田口岸</td></tr>
+          <tr><td>罗湖区</td><td>518000</td><td>东门、蔡屋围、国贸</td></tr>
+          <tr><td>南山区</td><td>518052</td><td>科技园、前海、后海</td></tr>
+          <tr><td>宝安区</td><td>518101</td><td>西乡、新安、福永</td></tr>
+          <tr><td>龙岗区</td><td>518116</td><td>坂田、布吉、龙城</td></tr>
+          <tr><td>龙华区</td><td>518110</td><td>民治、大浪、观澜</td></tr>
+          <tr><td>光明区</td><td>518107</td><td>光明、马田、公明</td></tr>
+          <tr><td>坪山区</td><td>518118</td><td>坪山、坑梓</td></tr>
+          <tr><td>盐田区</td><td>518081</td><td>大梅沙、小梅沙、盐田港</td></tr>
+          <tr><td>大鹏新区</td><td>518120</td><td>大鹏、南澳</td></tr>
+        </tbody>
+      </table>
+      <p>深圳邮编统一为 518xxx 开头，寄件/收件时可在英文地址末尾直接填写，如“Shenzhen Nanshan District, 518052 China”。</p>
+    </section>
+    <section class="card">
+      <h2>跨境寄递小贴士</h2>
+      <ul>
+        <li>关务与清关资料通常要求中英文地址对照，邮编保持 6 位数字即可。</li>
+        <li>口岸/保税区地址可能存在多个邮编，建议以园区官方客服提供的编码为准。</li>
+        <li>寄往香港、澳门时注意区分地区，内地邮编 518xxx 只适用于深圳本地。</li>
+        <li>更多规则请参考《<a href="https://postcode.blog/youbian-guize.html">邮编规则</a>》专题。</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -935,6 +935,38 @@
       </div>
     </section>
 
+    <section aria-labelledby="cn-resources">
+      <div class="section-header">
+        <div>
+          <p class="eyebrow">中文专题</p>
+          <h2 id="cn-resources">热门城市邮编与实用指南</h2>
+          <p>覆盖北京、上海、深圳的中文邮编落地页，并附邮编查询与规则科普。</p>
+        </div>
+      </div>
+      <div class="tool-grid">
+        <a class="tool-card" href="/city/beijing/youbian.html">
+          <h3>北京邮编大全</h3>
+          <p>16 个城区主邮编、寄件格式与查找器入口。</p>
+        </a>
+        <a class="tool-card" href="/city/shanghai/youbian.html">
+          <h3>上海邮编大全</h3>
+          <p>浦东、徐汇、静安等热门区域 6 位编码汇总。</p>
+        </a>
+        <a class="tool-card" href="/city/shenzhen/youbian.html">
+          <h3>深圳邮编大全</h3>
+          <p>福田、南山、龙华、宝安等片区邮编及跨境提示。</p>
+        </a>
+        <a class="tool-card" href="/youbian-zenme-cha.html">
+          <h3>邮编怎么查</h3>
+          <p>在线工具、客服核验与格式示例，快速找到 6 位编码。</p>
+        </a>
+        <a class="tool-card" href="/youbian-guize.html">
+          <h3>邮编规则</h3>
+          <p>解读 6 位数字结构、常见前缀与跨境填写规范。</p>
+        </a>
+      </div>
+    </section>
+
     <section aria-labelledby="faq">
       <div class="section-header">
         <div>

--- a/sitemap.html
+++ b/sitemap.html
@@ -324,6 +324,42 @@
                     </li>
                 </ul>
             </div>
+
+            <div class="sitemap-section">
+                <h3>中文邮编专题</h3>
+                <ul class="page-list">
+                    <li>
+                        <a href="/city/beijing/youbian.html">北京邮编大全</a>
+                        <div class="page-description">
+                            北京 16 个行政区主邮政编码、寄件格式示例与查询入口。
+                        </div>
+                    </li>
+                    <li>
+                        <a href="/city/shanghai/youbian.html">上海邮编大全</a>
+                        <div class="page-description">
+                            浦东、徐汇、静安等热门区域 6 位邮政编码列表及填写技巧。
+                        </div>
+                    </li>
+                    <li>
+                        <a href="/city/shenzhen/youbian.html">深圳邮编大全</a>
+                        <div class="page-description">
+                            福田、南山、龙华、宝安等片区邮编汇总，附跨境寄递提示。
+                        </div>
+                    </li>
+                    <li>
+                        <a href="/youbian-zenme-cha.html">邮编怎么查</a>
+                        <div class="page-description">
+                            覆盖在线查询、客服电话核验与常见错误排查的实用指南。
+                        </div>
+                    </li>
+                    <li>
+                        <a href="/youbian-guize.html">邮编规则</a>
+                        <div class="page-description">
+                            解析 6 位数字结构、常见前缀与跨境/政务表单填写规范。
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </section>
     </main>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -80,4 +80,29 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://postcode.blog/city/beijing/youbian.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/city/shanghai/youbian.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/city/shenzhen/youbian.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/youbian-zenme-cha.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/youbian-guize.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/youbian-guize.html
+++ b/youbian-guize.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>邮编规则：6位数字结构、填写规范与常见疑问</title>
+  <meta name="description" content="详细讲解中国邮编规则：6位数字结构含义、常见前缀、填写顺序、跨境电商与政务材料的邮政编码注意事项。">
+  <link rel="canonical" href="https://postcode.blog/youbian-guize.html">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="邮编规则：6位数字结构、填写规范与常见疑问">
+  <meta property="og:description" content="掌握邮编规则与格式，避免快递退回或政务资料被驳回。">
+  <meta property="og:url" content="https://postcode.blog/youbian-guize.html">
+  <meta property="og:site_name" content="Postcode Blog">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="邮编规则：6位数字结构、填写规范与常见疑问">
+  <meta name="twitter:description" content="掌握邮编规则与格式，避免快递退回或政务资料被驳回。">
+  <style>
+    body {font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif; margin: 0; padding: 0; background: #f7f9fb; color: #0f172a; line-height: 1.8;}
+    header, main {max-width: 960px; margin: auto; padding: 24px;}
+    h1 {font-size: 32px; margin-bottom: 10px;}
+    h2 {margin-top: 28px; font-size: 24px;}
+    p {margin: 12px 0;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; box-shadow: 0 10px 40px rgba(15,23,42,0.05);} 
+    ul {padding-left: 20px;}
+    table {width: 100%; border-collapse: collapse; margin-top: 12px;}
+    th, td {padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left;}
+    th {background: #f1f5f9; font-weight: 600;}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Postcode Blog · 邮编规则解读",
+    "description": "介绍中国邮编的6位数字结构、填写规范与跨境寄递注意事项。",
+    "url": "https://postcode.blog/youbian-guize.html",
+    "areaServed": {
+      "@type": "Country",
+      "name": "中国"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "CN"
+    },
+    "sameAs": [
+      "https://postcode.blog/youbian-zenme-cha.html"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <h1>邮编规则：6位数字结构、填写规范与常见疑问</h1>
+    <p>掌握邮编结构与填写规则，可以显著降低快递退件率。本文用简单例子解释 6 位数字的含义，并提供跨境、政务、票据场景的注意点。</p>
+  </header>
+  <main class="card">
+    <h2>邮编结构：前两位决定省份</h2>
+    <p>中国大陆邮政编码统一为 <strong>6 位数字</strong>，从左到右依次代表：</p>
+    <ul>
+      <li>第 1-2 位：省份或直辖市（如 10 表示北京，20 表示上海，51 表示四川）。</li>
+      <li>第 3-4 位：城市或地级行政区。</li>
+      <li>第 5-6 位：派送路线、区县或重要街道。</li>
+    </ul>
+    <p>示例：<mark>518052</mark> = 51（广东省） + 80（深圳市） + 52（南山区科技园片区）。</p>
+
+    <h2>常见前缀速查</h2>
+    <table>
+      <thead><tr><th>前两位</th><th>代表区域</th><th>示例邮编</th></tr></thead>
+      <tbody>
+        <tr><td>10</td><td>北京</td><td>100020 朝阳区</td></tr>
+        <tr><td>20</td><td>上海</td><td>200120 浦东新区</td></tr>
+        <tr><td>21</td><td>天津</td><td>300000 市区</td></tr>
+        <tr><td>51</td><td>广东省（含深圳、广州）</td><td>510000 广州市</td></tr>
+        <tr><td>61</td><td>陕西省</td><td>710000 西安市</td></tr>
+      </tbody>
+    </table>
+
+    <h2>正确填写格式</h2>
+    <ul>
+      <li>邮编必须写 6 位数字，不要添加空格或标点。</li>
+      <li>在中文地址末尾写邮编，如“北京市朝阳区建国路88号 100020”。</li>
+      <li>英文地址保持相同数字即可："No.88 Jianguo Rd, Chaoyang District, Beijing 100020, China"。</li>
+      <li>跨境表单（如亚马逊、eBay）仅需填写邮编数字，无需重复省市信息。</li>
+    </ul>
+
+    <h2>遇到这些情况怎么办？</h2>
+    <ul>
+      <li><strong>新区或新楼盘：</strong> 优先使用所在街道的主邮编，并向物业或快递员确认最新编码。</li>
+      <li><strong>乡镇/村邮寄：</strong> 填写镇级邮编即可，必要时附加村名或地标，确保可达性。</li>
+      <li><strong>多个编码同时出现：</strong> 选择与街道/社区名称最匹配的编码，并与快递客服二次核验。</li>
+    </ul>
+
+    <h2>延伸阅读</h2>
+    <ul>
+      <li><a href="/youbian-zenme-cha.html">邮编怎么查</a>：快速查询与排错方法</li>
+      <li><a href="/city/beijing/youbian.html">北京邮编大全</a></li>
+      <li><a href="/city/shanghai/youbian.html">上海邮编大全</a></li>
+      <li><a href="/city/shenzhen/youbian.html">深圳邮编大全</a></li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/youbian-zenme-cha.html
+++ b/youbian-zenme-cha.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>邮编怎么查？最快的邮政编码查询方法与格式示例</title>
+  <meta name="description" content="邮编怎么查？提供在线邮政编码查询、手机查询、人工确认等多种方法，并附上填写格式、错误排查与跨境寄件注意事项。">
+  <link rel="canonical" href="https://postcode.blog/youbian-zenme-cha.html">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="邮编怎么查？最快的邮政编码查询方法与格式示例">
+  <meta property="og:description" content="从在线工具到客服电话，全面介绍邮政编码的查询技巧与填写规范。">
+  <meta property="og:url" content="https://postcode.blog/youbian-zenme-cha.html">
+  <meta property="og:site_name" content="Postcode Blog">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="邮编怎么查？最快的邮政编码查询方法与格式示例">
+  <meta name="twitter:description" content="从在线工具到客服电话，全面介绍邮政编码的查询技巧与填写规范。">
+  <style>
+    body {font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif; margin: 0; padding: 0; background: #f7f9fb; color: #0f172a; line-height: 1.8;}
+    header, main {max-width: 960px; margin: auto; padding: 24px;}
+    h1 {font-size: 32px; margin-bottom: 10px;}
+    h2 {margin-top: 28px; font-size: 24px;}
+    p {margin: 12px 0;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; box-shadow: 0 10px 40px rgba(15,23,42,0.05);} 
+    ol, ul {padding-left: 20px;}
+    mark {background: #e0f2fe; padding: 2px 6px; border-radius: 6px;}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Postcode Blog · 邮编查询指南",
+    "description": "提供中国邮政编码在线查询、格式说明与寄递填写技巧。",
+    "url": "https://postcode.blog/youbian-zenme-cha.html",
+    "areaServed": {
+      "@type": "Country",
+      "name": "中国"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "CN"
+    },
+    "sameAs": [
+      "https://postcode.blog/finder/",
+      "https://postcode.blog/lookup/"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <h1>邮编怎么查？最快的邮政编码查询方法</h1>
+    <p>寄快递、开通水电燃气、填写银行卡地址或出国签证，都需要准确的 6 位邮政编码。下面总结 4 种高效方法，并提供常见错误排查清单。</p>
+  </header>
+  <main class="card">
+    <h2>1）在线工具查询</h2>
+    <ol>
+      <li>打开 <a href="https://postcode.blog/finder/" target="_blank" rel="noopener">邮编查找器</a>，输入完整中文地址（省/市/区/街道/小区）。</li>
+      <li>按提示选择候选地址，复制返回的 6 位编码。例如“北京市朝阳区建国路 88 号”会返回 <mark>100020</mark>。</li>
+      <li>若需要英文，可在结果页直接复制「中英文地址 + 邮编」组合，方便跨境电商填写。</li>
+    </ol>
+
+    <h2>2）地图与导航软件</h2>
+    <p>高德、百度地图等也会在详情页展示邮编，但部分新建小区可能没有收录。可与在线查找器结果交叉验证。</p>
+
+    <h2>3）拨打官方/快递客服</h2>
+    <ul>
+      <li>中国邮政：11185</li>
+      <li>顺丰：95338；京东：950616；极兔：95721</li>
+      <li>提供「街道 + 门牌号」即可，请记录客服确认的 6 位数字。</li>
+    </ul>
+
+    <h2>4）现场查阅</h2>
+    <p>社区公告栏、物业、派出所或学校档案室通常会张贴邮编。对于乡镇/村庄地址，建议与乡镇政府核实后再寄件。</p>
+
+    <h2>常见错误排查</h2>
+    <ul>
+      <li><strong>只填前 3~4 位：</strong> 邮编必须 6 位数字，缺少末两位容易被退件。</li>
+      <li><strong>沿用旧邮编：</strong> 行政区划调整后可能更换编码，新楼盘请先查询最新记录。</li>
+      <li><strong>中英文不一致：</strong> 英文地址无需翻译邮编，直接使用相同数字即可。</li>
+      <li><strong>格式写错：</strong> 推荐写在地址末尾，如“上海市浦东新区世纪大道100号 200120”。</li>
+    </ul>
+
+    <h2>下一步：查具体城市</h2>
+    <p>热门城市已整理专页，直接查看即可：</p>
+    <ul>
+      <li><a href="/city/beijing/youbian.html">北京邮编大全</a></li>
+      <li><a href="/city/shanghai/youbian.html">上海邮编大全</a></li>
+      <li><a href="/city/shenzhen/youbian.html">深圳邮编大全</a></li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Chinese landing pages for Beijing, Shanghai, and Shenzhen with LocalBusiness schema and postcode tables
- publish Chinese guides on how to find postcodes and rules for six-digit formatting
- surface new resources from the homepage, XML sitemap, and HTML sitemap for discoverability

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4a20ecec8321ac4fb43fb319ba8a)