### PR TITLE
Fix homepage CN resources grid styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,9 +267,15 @@
     .quick-cities,
     .province-grid,
     .faq-preview,
-    .tools-grid {
+    .tools-grid,
+    .tool-grid {
       display: grid;
       gap: 1.5rem;
+    }
+
+    .tools-grid,
+    .tool-grid {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
     .search-block {
@@ -943,7 +949,7 @@
           <p>覆盖北京、上海、深圳的中文邮编落地页，并附邮编查询与规则科普。</p>
         </div>
       </div>
-      <div class="tool-grid">
+      <div class="tools-grid">
         <a class="tool-card" href="/city/beijing/youbian.html">
           <h3>北京邮编大全</h3>
           <p>16 个城区主邮编、寄件格式与查找器入口。</p>


### PR DESCRIPTION
### Motivation
- The Chinese resources section (热门城市邮编与实用指南) was not using the shared tools grid and had inconsistent layout compared to other tool cards.
- Align `.tool-grid` with the existing `.tools-grid` rules so cards follow the same responsive sizing behavior.
- Ensure the CN resources cards display in consistent columns across viewports by setting an explicit `grid-template-columns`.

### Description
- Added `.tool-grid` to the existing grid selector and introduced a shared `grid-template-columns` rule for `.tools-grid` and `.tool-grid` in `index.html`.
- Replaced the CN resources container from `<div class="tool-grid">` to `<div class="tools-grid">` so it uses the shared styles.
- Changes are limited to static CSS/HTML in `index.html` and only affect layout and responsiveness of the homepage cards.

### Testing
- Launched a local server with `python -m http.server`, which started successfully.
- Attempted a Playwright screenshot to validate the visual layout, but the script timed out and the check failed.
- No automated unit tests were executed for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948da25d7e88321bd293a03be49d4c1)