### PR TITLE
Fix canonical tag and expand sitemap coverage

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>China Zip Code Search — Complete Chinese Postcode Directory</title>
   <meta name="description" content="Browse all China zip/postal codes by province & city. Beijing, Shanghai, Guangdong, Shenzhen, Chengdu, Nanjing… updated & accurate.">
-  <link rel="canonical" href="https://postcode.blog/finder/" />
+  <link rel="canonical" href="https://postcode.blog/search/" />
   <meta name="robots" content="index,follow">
   <meta property="og:type" content="website">
   <meta property="og:title" content="China Zip Code Search — Complete Chinese Postcode Directory">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,27 +8,97 @@
   <url>
     <loc>https://postcode.blog/finder/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://postcode.blog/lookup/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://postcode.blog/search/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://postcode.blog/faq/</loc>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://postcode.blog/cities/</loc>
     <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/map/</loc>
+    <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/global.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/sitemap.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/postal-code-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/post-office.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/us-zip-codes.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/hotel-directory.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/mobile-sim-cards.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/china-mobile-sim.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/china-unicom-sim.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/china-telecom-sim.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/youbian-zenme-cha.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/youbian-guize.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://postcode.blog/statistics.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
   </url>
   <url>
     <loc>https://postcode.blog/province/guangdong/</loc>
@@ -51,12 +121,12 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://postcode.blog/city/guangzhou/</loc>
+    <loc>https://postcode.blog/city/shenzhen/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://postcode.blog/city/shenzhen/</loc>
+    <loc>https://postcode.blog/city/guangzhou/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -83,26 +153,16 @@
   <url>
     <loc>https://postcode.blog/city/beijing/youbian.html</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://postcode.blog/city/shanghai/youbian.html</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://postcode.blog/city/shenzhen/youbian.html</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://postcode.blog/youbian-zenme-cha.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://postcode.blog/youbian-guize.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.6</priority>
   </url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Correct the canonical URL on the search directory page so it points to the actual `search` path for proper SEO signals.
- Ensure the XML sitemap covers all public pages and important city/province hub pages to improve indexing and discovery.
- Adjust priorities and change frequencies to better reflect the relative importance and update cadence of pages.

### Description
- Updated the canonical link in `search/index.html` from `https://postcode.blog/finder/` to `https://postcode.blog/search/`.
- Rewrote `sitemap.xml` to add many existing pages (content pages, mobile SIM pages, city and province hubs) and adjusted `priority` and `changefreq` values.
- Fixed ordering/mapping for city entries (swapped `shenzhen`/`guangzhou` entries) and lowered `priority` values for individual city postcode pages.
- Modified files: `search/index.html` and `sitemap.xml`.

### Testing
- No automated tests were run because these are static HTML/XML content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955f874ef488321935532714d7f3d2d)